### PR TITLE
Reward and Interstitial ads bug fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ function fail(result)
 <h4>Syntax</h4>
 
 ```javascript
-cordova.plugins.codeplayfacebookads.loadInterstitialAds(options,success,fail);
+cordova.plugins.codeplayfacebookads.loadInterstitialAds(options,events,fail);
 ```
 
 <h4>Options</h4>
@@ -134,11 +134,25 @@ interstitialid:"52351930143xxx_xxxxxxxxxxxxxxx"
 ,isTesting:true
 };
 
-cordova.plugins.codeplayfacebookads.loadInterstitialAds(options,success,fail);
+cordova.plugins.codeplayfacebookads.loadInterstitialAds(options,events,fail);
 
-function success(result)
+function events(event)
 {
- console.log(result);
+  if(event === "AdLoaded"){
+	 console.log("AdLoaded");
+  }
+  else if(event === "AdClosed"){
+	 console.log("AdClosed");
+  }
+  else if(event === "AdDisplayed"){
+	 console.log("AdDisplayed");
+  }
+  else if(event === "AdClicked"){
+	 console.log("AdClicked");
+  }
+  else if(event === "AdLogged"){
+	 console.log("AdLogged");
+  }
 }
 function fail(result)
 {
@@ -192,7 +206,7 @@ function fail(result)
 <h4>Syntax</h4>
 
 ```javascript
-cordova.plugins.codeplayfacebookads.loadRewardVideoAd(options,success,fail);
+cordova.plugins.codeplayfacebookads.loadRewardVideoAd(options,events,fail);
 ```
 
 <h4>Options</h4>
@@ -213,12 +227,27 @@ videoid:"52351930143xxx_xxxxxxxxxxxxxxx"
 ,isTesting:true
 };
 
-cordova.plugins.codeplayfacebookads.loadRewardVideoAd(options,success,fail);
+cordova.plugins.codeplayfacebookads.loadRewardVideoAd(options,events,fail);
 
-function success(result)
+function events(event)
 {
- console.log(result);
+  if(event === "AdLoaded"){
+	 console.log("AdLoaded");
+  }
+  else if(event === "AdClosed"){
+	 console.log("AdClosed");
+  }
+  else if(event === "AdPlaying"){
+	 console.log("AdPlaying");
+  }
+  else if(event === "AdClicked"){
+	 console.log("AdClicked");
+  }
+  else if(event === "AdCompleted"){
+	 console.log("AdCompleted");
+  }
 }
+
 function fail(result)
 {
  console.log(result);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-codeplay-facebookads-free",
-  "version": "0.0.3",
+  "version": "1.1",
   "description": "Free facebook audience network ads for cordova user. This supports banner and Interstitial ads.",
   "cordova": {
     "id": "cordova-plugin-codeplay-facebookads-free",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version='1.1' encoding='utf-8'?>
 <plugin id="cordova-plugin-codeplay-facebookads-free" version="0.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>codeplayfacebookads</name>
   <js-module name="codeplayfacebookads" src="www/codeplayfacebookads.js">

--- a/src/android/codeplayfacebookads.java
+++ b/src/android/codeplayfacebookads.java
@@ -306,7 +306,7 @@ public class codeplayfacebookads extends CordovaPlugin {
 
                 //callbackContext.success("Rewarded video completed!");
 				PluginResult result = new PluginResult(PluginResult.Status.OK, "AdCompleted");				
-				//result.setKeepCallback(true);
+				result.setKeepCallback(true);
 				callbackContext.sendPluginResult(result);
                 // Call method to give reward
                 // giveReward();
@@ -408,12 +408,18 @@ public class codeplayfacebookads extends CordovaPlugin {
             @Override
             public void onInterstitialDisplayed(Ad ad) {                
 				isInterstitialLoad=false;
-				callbackContext.success("Facebook interstitial Ads displayed.");
+                // callbackContext.success("Facebook interstitial Ads displayed.");
+                PluginResult result = new PluginResult(PluginResult.Status.OK, "AdDisplayed");				
+				result.setKeepCallback(true);
+				callbackContext.sendPluginResult(result);
             }
 
             @Override
             public void onInterstitialDismissed(Ad ad) {
-                callbackContext.success("Facebook interstitial Ads dismissed");
+                // callbackContext.success("Facebook interstitial Ads dismissed");
+                PluginResult result = new PluginResult(PluginResult.Status.OK, "AdClosed");				
+				//result.setKeepCallback(true);
+				callbackContext.sendPluginResult(result);
             }
 
             @Override
@@ -425,17 +431,25 @@ public class codeplayfacebookads extends CordovaPlugin {
             @Override
             public void onAdLoaded(Ad ad) {
 				isInterstitialLoad=true;
-                callbackContext.success("Facebook interstitial Ads is loaded and ready to be displayed!");
+                PluginResult result = new PluginResult(PluginResult.Status.OK, "AdLoaded");				
+				result.setKeepCallback(true);
+				callbackContext.sendPluginResult(result);
             }
 
             @Override
             public void onAdClicked(Ad ad) {
-                callbackContext.success("Facebook interstitial Ads clicked!");
+                // callbackContext.success("Facebook interstitial Ads clicked!");
+                PluginResult result = new PluginResult(PluginResult.Status.OK, "AdClicked");				
+				result.setKeepCallback(true);
+				callbackContext.sendPluginResult(result);
             }
 
             @Override
             public void onLoggingImpression(Ad ad) {
-                callbackContext.success("Facebook interstitial Ads impression logged!");
+                // callbackContext.success("Facebook interstitial Ads impression logged!");
+                PluginResult result = new PluginResult(PluginResult.Status.OK, "AdLogged");				
+				result.setKeepCallback(true);
+				callbackContext.sendPluginResult(result);
             }
         });
 

--- a/src/android/facebook-sdk.gradle
+++ b/src/android/facebook-sdk.gradle
@@ -1,4 +1,5 @@
 dependencies {
-  implementation 'com.android.support:recyclerview-v7:25.3.1' // Required Dependency by Audience Network SDK
+  //implementation 'com.android.support:recyclerview-v7:25.3.1' // Required Dependency by Audience Network SDK
+  //implementation 'com.android.support:recyclerview-v7:26.1.0' // Required Dependency by Audience Network SDK
   implementation 'com.facebook.android:audience-network-sdk:5.+'
 }


### PR DESCRIPTION
Hi here are few updates I made.

1. The reward video ads were being auto played, when they are loaded, i.e before a showRewardVideoAd() request is made. So I have fixed this issue.
2. I have replaced success methods in the loadRewardVideoAd() with events method, which actually triggers during events such as "AdLoaded", "AdClosed", "AdPlaying" "AdClicked" and "AdCompleted".
3. Same thing with loadInterstitialAds() method,  it has the following events "AdLoaded", "AdClosed", "AdDisplayed", "AdClicked", and "AdLogged". 

I have been using all these changes since last 2 months in my app. So everything is working fine without issues.